### PR TITLE
Login: move password toggle button

### DIFF
--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -70,11 +70,8 @@
 
 	function resetToggle( show ) {
 		$toggleButton
-			.attr({
-				'aria-label': show ? __( 'Show password' ) : __( 'Hide password' )
-			})
 			.find( '.text' )
-				.text( show ? __( 'Show' ) : __( 'Hide' ) )
+				.text( show ? __( 'Show password' ) : __( 'Hide password' ) )
 			.end()
 			.find( '.dashicons' )
 				.removeClass( show ? 'dashicons-hidden' : 'dashicons-visibility' )

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -69,13 +69,26 @@
 	}
 
 	function resetToggle( show ) {
-		$toggleButton
-			.find( '.text' )
-				.text( show ? __( 'Show password' ) : __( 'Hide password' ) )
-			.end()
-			.find( '.dashicons' )
-				.removeClass( show ? 'dashicons-hidden' : 'dashicons-visibility' )
-				.addClass( show ? 'dashicons-visibility' : 'dashicons-hidden' );
+		if ( $( 'body' ).hasClass( 'login' ) ) {
+			$toggleButton
+				.find( '.text' )
+					.text( show ? __( 'Show password' ) : __( 'Hide password' ) )
+				.end()
+				.find( '.dashicons' )
+					.removeClass( show ? 'dashicons-hidden' : 'dashicons-visibility' )
+					.addClass( show ? 'dashicons-visibility' : 'dashicons-hidden' );
+		} else {
+			$toggleButton
+				.attr({
+					'aria-label': show ? __( 'Show password' ) : __( 'Hide password' )
+				})
+				.find( '.text' )
+					.text( show ? __( 'Show' ) : __( 'Hide' ) )
+				.end()
+				.find( '.dashicons' )
+					.removeClass( show ? 'dashicons-hidden' : 'dashicons-visibility' )
+					.addClass( show ? 'dashicons-visibility' : 'dashicons-hidden' );
+		}
 	}
 
 	function bindToggleButton() {

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -80,8 +80,11 @@ p {
 	margin-bottom: 15px;
 }
 
-.login .button.wp-hide-pw {
+.login .wp-hide-pw {
 	display: block;
+}
+
+.login .button.wp-hide-pw {
 	background: transparent;
 	border: 1px solid transparent;
 	box-shadow: none;

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -88,8 +88,9 @@ p {
 	background: transparent;
 	border: 1px solid transparent;
 	box-shadow: none;
-	line-height: 2;
 	font-size: 12px;
+	line-height: 2;
+	width: auto;
 	height: 1.25rem;
 	margin: -12px 0 16px auto;
 	padding: 0 2px;
@@ -129,7 +130,6 @@ p {
 @media screen and (max-width: 782px) {
 	.login .button.wp-hide-pw {
 		right: auto;
-		width: auto;
 	}
 
 	.login .button.wp-hide-pw .text {

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -81,20 +81,17 @@ p {
 }
 
 .login .button.wp-hide-pw {
+	display: block;
 	background: transparent;
 	border: 1px solid transparent;
 	box-shadow: none;
-	font-size: 14px;
 	line-height: 2;
-	width: 2.5rem;
-	height: 2.5rem;
-	min-width: 40px;
-	min-height: 40px;
-	margin: 0;
-	padding: 5px 9px;
-	position: absolute;
-	right: 0;
-	top: 0;
+	font-size: 12px;
+	height: 1.25rem;
+	margin: -12px 0 12px auto;
+	padding: 0 2px;
+	position: relative;
+	z-index: 10;
 }
 
 .login .button.wp-hide-pw:hover {
@@ -116,13 +113,25 @@ p {
 }
 
 .login .button.wp-hide-pw .dashicons {
-	width: 1.25rem;
+	width: 1rem;
 	height: 1.25rem;
 	top: 0.25rem;
+	font-size: 16px;
 }
 
 .login .wp-pwd {
 	position: relative;
+}
+
+@media screen and (max-width: 782px) {
+	.login .button.wp-hide-pw {
+		right: auto;
+		width: auto;
+	}
+
+	.login .button.wp-hide-pw .text {
+		display: inline;
+	}
 }
 
 .no-js .hide-if-no-js {
@@ -340,12 +349,6 @@ p {
 
 .login input.password-input {
 	font-family: Consolas, Monaco, monospace;
-}
-
-.js.login input.password-input,
-.js.login-action-rp form .input,
-.js.login-action-rp input[type="text"] {
-	padding-right: 2.5rem;
 }
 
 .login form .input,

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -91,7 +91,7 @@ p {
 	line-height: 2;
 	font-size: 12px;
 	height: 1.25rem;
-	margin: -12px 0 12px auto;
+	margin: -12px 0 16px auto;
 	padding: 0 2px;
 	position: relative;
 	z-index: 10;

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -943,10 +943,11 @@ switch ( $action ) {
 				<div class="wp-pwd">
 					<input type="password" data-reveal="1" data-pw="<?php echo esc_attr( wp_generate_password( 16 ) ); ?>" name="pass1" id="pass1" class="input password-input" size="24" value="" autocomplete="off" aria-describedby="pass-strength-result" />
 
-					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
-						<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
-					</button>
 					<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite"><?php _e( 'Strength indicator' ); ?></div>
+					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0">
+						<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
+						<span class="text"><?php _e( 'Hide password' ); ?></span>
+					</button>
 				</div>
 				<div class="pw-weak">
 					<input type="checkbox" name="pw_weak" id="pw-weak" class="pw-checkbox" />
@@ -1394,8 +1395,9 @@ switch ( $action ) {
 				<label for="user_pass"><?php _e( 'Password' ); ?></label>
 				<div class="wp-pwd">
 					<input type="password" name="pwd" id="user_pass"<?php echo $aria_describedby_error; ?> class="input password-input" value="" size="20" />
-					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Show password' ); ?>">
+					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0">
 						<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
+						<span class="text"><?php _e( 'Show password' ); ?></span>
 					</button>
 				</div>
 			</div>

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -945,8 +945,8 @@ switch ( $action ) {
 
 					<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite"><?php _e( 'Strength indicator' ); ?></div>
 					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0">
-						<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 						<span class="text"><?php _e( 'Hide password' ); ?></span>
+						<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 					</button>
 				</div>
 				<div class="pw-weak">
@@ -1396,8 +1396,8 @@ switch ( $action ) {
 				<div class="wp-pwd">
 					<input type="password" name="pwd" id="user_pass"<?php echo $aria_describedby_error; ?> class="input password-input" value="" size="20" />
 					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0">
-						<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 						<span class="text"><?php _e( 'Show password' ); ?></span>
+						<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
Make room for password managers such as LastPass by moving the visibility toggle button, and show the button label text.

Trac ticket: https://core.trac.wordpress.org/ticket/48222

Moving the eye icon after the text can make the width difference less noticeable. Plus, this adds a little more to the bottom margin.

**Login**

![login screen with proposed icon repositioning](https://user-images.githubusercontent.com/17100257/160030018-329ab195-451c-4bad-9553-8493d70de788.jpg)

**Reset Password**

![reset password screen with proposed icon repositioning](https://user-images.githubusercontent.com/17100257/160030019-6935bb79-71a3-41f0-81cb-23864bc5bc25.jpg)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
