### PR TITLE
Login password visibility: Add container `div` and use `display: flex`

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -125,6 +125,20 @@ p {
 	position: relative;
 }
 
+.js.login .has-password-toggle {
+	display: flex;
+}
+
+.js.login .has-password-toggle .password-input {
+	padding-right: 0.3125rem;
+}
+
+.js.login .has-password-toggle .button.wp-hide-pw {
+	border-color: currentColor;
+	border-radius: 4px;
+	position: static;
+}
+
 .no-js .hide-if-no-js {
 	display: none;
 }

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -954,11 +954,13 @@ switch ( $action ) {
 				</p>
 
 				<div class="wp-pwd">
-					<input type="password" data-reveal="1" data-pw="<?php echo esc_attr( wp_generate_password( 16 ) ); ?>" name="pass1" id="pass1" class="input password-input" size="24" value="" autocomplete="new-password" aria-describedby="pass-strength-result" />
+					<div class="has-password-toggle">
+						<input type="password" data-reveal="1" data-pw="<?php echo esc_attr( wp_generate_password( 16 ) ); ?>" name="pass1" id="pass1" class="input password-input" size="24" value="" autocomplete="new-password" aria-describedby="pass-strength-result" />
 
-					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
-						<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
-					</button>
+						<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
+							<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
+						</button>
+					</div>
 					<div id="pass-strength-result" class="hide-if-no-js" aria-live="polite"><?php _e( 'Strength indicator' ); ?></div>
 				</div>
 				<div class="pw-weak">
@@ -1410,7 +1412,7 @@ switch ( $action ) {
 
 			<div class="user-pass-wrap">
 				<label for="user_pass"><?php _e( 'Password' ); ?></label>
-				<div class="wp-pwd">
+				<div class="wp-pwd has-password-toggle"">
 					<input type="password" name="pwd" id="user_pass"<?php echo $aria_describedby; ?> class="input password-input" value="" size="20" autocomplete="current-password" />
 					<button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Show password' ); ?>">
 						<span class="dashicons dashicons-visibility" aria-hidden="true"></span>


### PR DESCRIPTION
This is a simpler option for accommodating password managers, only changing the display for Login screens (not the user screens). See [Trac ticket #48222](https://core.trac.wordpress.org/ticket/48222).

The transparent border does not make sense with this, so the `border-color` is set to `currentColor` (PR #1 had `inherit`). Also, the `border-radius` now matches the input field.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
