### PR TITLE
Consider making `twentyseventeen_is_static_front_page()` canonical

### DIFF
--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -266,7 +266,7 @@ function twentyseventeen_content_width() {
 
 	// Check if layout is one column.
 	if ( 'one-column' === $page_layout ) {
-		if ( twentyseventeen_is_frontpage() ) {
+		if ( twentyseventeen_is_static_front_page() ) {
 			$content_width = 644;
 		} elseif ( is_page() ) {
 			$content_width = 740;

--- a/src/wp-content/themes/twentyseventeen/header.php
+++ b/src/wp-content/themes/twentyseventeen/header.php
@@ -52,7 +52,7 @@
 	 * If a regular post or page, and not the front page, show the featured image.
 	 * Using get_queried_object_id() here since the $post global may not be set before a call to the_post().
 	 */
-	if ( ( is_single() || ( is_page() && ! twentyseventeen_is_frontpage() ) ) && has_post_thumbnail( get_queried_object_id() ) ) :
+	if ( ( is_single() || ( is_page() && ! twentyseventeen_is_static_front_page() ) ) && has_post_thumbnail( get_queried_object_id() ) ) :
 		echo '<div class="single-featured-image-header">';
 		echo get_the_post_thumbnail( get_queried_object_id(), 'twentyseventeen-featured-image' );
 		echo '</div><!-- .single-featured-image-header -->';

--- a/src/wp-content/themes/twentyseventeen/inc/template-functions.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-functions.php
@@ -69,7 +69,7 @@ add_filter( 'body_class', 'twentyseventeen_body_classes' );
 /**
  * Count our number of active panels.
  *
- * Primarily used to see if we have any panels active, duh.
+ * Primarily used to see if we have any panels active.
  */
 function twentyseventeen_panel_count() {
 
@@ -96,7 +96,14 @@ function twentyseventeen_panel_count() {
 
 /**
  * Checks to see if we're on the front page or not.
+ *
+ * This function is an alias for twentyseventeen_is_static_front_page().
+ *
+ * @since Twenty Seventeen 1.0
+ * @since Twenty Seventeen 3.3 Converted function to an alias.
+ *
+ * @return bool Whether the current page is the front page and static.
  */
 function twentyseventeen_is_frontpage() {
-	return ( is_front_page() && ! is_home() );
+	return twentyseventeen_is_static_front_page();
 }

--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'twentyseventeen_entry_footer' ) ) :
 		// Get Tags for posts.
 		$tags_list = get_the_tag_list( '', $separate_meta );
 
-		// We don't want to output .entry-footer if it will be empty, so make sure its not.
+		// We don't want to output .entry-footer if it will be empty, so make sure it is not.
 		if ( ( ( twentyseventeen_categorized_blog() && $categories_list ) || $tags_list ) || get_edit_post_link() ) {
 
 			echo '<footer class="entry-footer">';

--- a/src/wp-content/themes/twentyseventeen/template-parts/header/site-branding.php
+++ b/src/wp-content/themes/twentyseventeen/template-parts/header/site-branding.php
@@ -30,7 +30,7 @@
 			<?php endif; ?>
 		</div><!-- .site-branding-text -->
 
-		<?php if ( ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) && ! has_nav_menu( 'top' ) ) : ?>
+		<?php if ( ( twentyseventeen_is_static_front_page() || ( is_home() && is_front_page() ) ) && ! has_nav_menu( 'top' ) ) : ?>
 		<a href="#content" class="menu-scroll-down"><?php echo twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ); ?><span class="screen-reader-text">
 			<?php
 			/* translators: Hidden accessibility text. */

--- a/src/wp-content/themes/twentyseventeen/template-parts/navigation/navigation-top.php
+++ b/src/wp-content/themes/twentyseventeen/template-parts/navigation/navigation-top.php
@@ -27,7 +27,7 @@
 	);
 	?>
 
-	<?php if ( ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) && has_custom_header() ) : ?>
+	<?php if ( ( twentyseventeen_is_static_front_page() || ( is_home() && is_front_page() ) ) && has_custom_header() ) : ?>
 		<a href="#content" class="menu-scroll-down"><?php echo twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ); ?><span class="screen-reader-text">
 			<?php
 			/* translators: Hidden accessibility text. */


### PR DESCRIPTION
- Updates the `twentyseventeen_is_frontpage()` to use `twentyseventeen_is_static_front_page()`
- Uses `twentyseventeen_is_static_front_page()` for all instances in the theme
- Adds a few extra documentation changes, which may fit better in the general Docblock updates ticket for 6.3

Trac ticket: https://core.trac.wordpress.org/ticket/43515

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
