### PR TITLE
Latest Posts block: remove `excerpt_more` filter and add distinguishable "Read more" links

### DIFF
--- a/src/wp-includes/blocks/latest-posts.php
+++ b/src/wp-includes/blocks/latest-posts.php
@@ -48,14 +48,6 @@ function render_block_core_latest_posts( $attributes ) {
 	$block_core_latest_posts_excerpt_length = $attributes['excerptLength'];
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
-	$filter_latest_posts_excerpt_more = static function ( $more ) use ( $attributes ) {
-		$use_excerpt = 'excerpt' === $attributes['displayPostContentRadio'];
-		/* translators: %1$s is a URL to a post, excerpt truncation character, default … */
-		return $use_excerpt ? sprintf( __( ' … <a href="%1$s" rel="noopener noreferrer">Read more</a>' ), esc_url( get_permalink() ) ) : $more;
-	};
-
-	add_filter( 'excerpt_more', $filter_latest_posts_excerpt_more );
-
 	if ( ! empty( $attributes['categories'] ) ) {
 		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 	}
@@ -150,6 +142,16 @@ function render_block_core_latest_posts( $attributes ) {
 			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
 
 			$trimmed_excerpt = get_the_excerpt( $post );
+
+			if ( str_ends_with( $trimmed_excerpt, ' [&hellip;]' ) ) {
+				$trimmed_excerpt .= sprintf(
+					' <a class="wp-block-latest-posts__post-read-more" href="%1$s" rel="noopener noreferrer" aria-label="%2$s">%3$s</a>',
+					esc_url( $post_link ),
+					/* translators: %s: Post title. */
+					sprintf( __( 'Read more of &#8220;%s&#8221;' ), esc_html( $title ) ),
+					__( 'Read more' )
+				);
+			}
 
 			if ( post_password_required( $post ) ) {
 				$trimmed_excerpt = __( 'This content is password protected.' );

--- a/src/wp-includes/blocks/latest-posts.php
+++ b/src/wp-includes/blocks/latest-posts.php
@@ -145,11 +145,10 @@ function render_block_core_latest_posts( $attributes ) {
 
 			if ( str_ends_with( $trimmed_excerpt, ' [&hellip;]' ) ) {
 				$trimmed_excerpt .= sprintf(
-					' <a class="wp-block-latest-posts__post-read-more" href="%1$s" rel="noopener noreferrer" aria-label="%2$s">%3$s</a>',
+					' <a class="wp-block-latest-posts__post-read-more" href="%1$s" rel="noopener noreferrer">%2$s</a>',
 					esc_url( $post_link ),
-					/* translators: %s: Post title. */
-					sprintf( __( 'Read more of &#8220;%s&#8221;' ), esc_html( $title ) ),
-					__( 'Read more' )
+					/* translators: %s: Post title. Only visible to screen readers. */
+					sprintf( __( 'Read more<span class="screen-reader-text"> of &#8220;%s&#8221;</span>' ), esc_html( $title ) )
 				);
 			}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
