### PR TITLE
Remove title attributes from author link functions and update unit tests

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -238,10 +238,8 @@ function get_the_author_link() {
 		$author_display_name = get_the_author();
 
 		$link = sprintf(
-			'<a href="%1$s" title="%2$s" rel="author external">%3$s</a>',
+			'<a href="%1$s" rel="author external">%2$s</a>',
 			esc_url( $author_url ),
-			/* translators: %s: Author's display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), $author_display_name ) ),
 			$author_display_name
 		);
 
@@ -318,10 +316,8 @@ function get_the_author_posts_link() {
 	}
 
 	$link = sprintf(
-		'<a href="%1$s" title="%2$s" rel="author">%3$s</a>',
+		'<a href="%1$s" rel="author">%2$s</a>',
 		esc_url( get_author_posts_url( $authordata->ID, $authordata->user_nicename ) ),
-		/* translators: %s: Author's display name. */
-		esc_attr( sprintf( __( 'Posts by %s' ), get_the_author() ) ),
 		get_the_author()
 	);
 
@@ -531,10 +527,8 @@ function wp_list_authors( $args = '' ) {
 		}
 
 		$link = sprintf(
-			'<a href="%1$s" title="%2$s">%3$s</a>',
+			'<a href="%1$s">%2$s</a>',
 			esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
-			/* translators: %s: Author's display name. */
-			esc_attr( sprintf( __( 'Posts by %s' ), $author->display_name ) ),
 			$name
 		);
 

--- a/tests/phpunit/tests/user/getTheAuthorPostsLink.php
+++ b/tests/phpunit/tests/user/getTheAuthorPostsLink.php
@@ -51,7 +51,6 @@ class Tests_User_GetTheAuthorPostsLink extends WP_UnitTestCase {
 		$url = sprintf( 'http://%1$s/?author=%2$s', WP_TESTS_DOMAIN, $author->ID );
 
 		$this->assertStringContainsString( $url, $link );
-		$this->assertStringContainsString( 'Posts by Test Author', $link );
 		$this->assertStringContainsString( '>Test Author</a>', $link );
 
 		unset( $GLOBALS['authordata'] );
@@ -74,7 +73,6 @@ class Tests_User_GetTheAuthorPostsLink extends WP_UnitTestCase {
 		$this->set_permalink_structure( '' );
 
 		$this->assertStringContainsString( $url, $link );
-		$this->assertStringContainsString( 'Posts by Test Author', $link );
 		$this->assertStringContainsString( '>Test Author</a>', $link );
 
 		unset( $GLOBALS['authordata'] );

--- a/tests/phpunit/tests/user/wpListAuthors.php
+++ b/tests/phpunit/tests/user/wpListAuthors.php
@@ -87,18 +87,18 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 
 	public function test_wp_list_authors_default() {
 		$expected['default'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a></li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>';
 
 		$this->assertSame( $expected['default'], wp_list_authors( array( 'echo' => false ) ) );
 	}
 
 	public function test_wp_list_authors_orderby() {
 		$expected['post_count'] =
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a></li>' .
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a></li>';
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>' .
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>';
 
 		$this->assertSame(
 			$expected['post_count'],
@@ -113,9 +113,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 
 	public function test_wp_list_authors_order() {
 		$expected['id'] =
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a></li>' .
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a></li>';
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>' .
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>';
 
 		$this->assertSame(
 			$expected['id'],
@@ -131,9 +131,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 
 	public function test_wp_list_authors_optioncount() {
 		$expected['optioncount'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a> (2)</li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a> (3)</li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a> (1)</li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a> (2)</li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a> (3)</li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a> (1)</li>';
 
 		$this->assertSame(
 			$expected['optioncount'],
@@ -180,10 +180,10 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 		);
 
 		$expected['exclude_admin'] =
-			'<li><a href="' . get_author_posts_url( 1 ) . '" title="Posts by admin">admin</a></li>' .
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a></li>';
+			'<li><a href="' . get_author_posts_url( 1 ) . '">admin</a></li>' .
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>';
 
 		$this->assertSame(
 			$expected['exclude_admin'],
@@ -198,9 +198,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 
 	public function test_wp_list_authors_show_fullname() {
 		$expected['show_fullname'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob reno</a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul norris</a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack moon</a></li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob reno</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul norris</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack moon</a></li>';
 
 		$this->assertSame(
 			$expected['show_fullname'],
@@ -217,10 +217,10 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 		$fred_id = self::$fred_id;
 
 		$expected['hide_empty'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a></li>' .
-			'<li><a href="' . get_author_posts_url( $fred_id ) . '" title="Posts by fred">fred</a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a></li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . get_author_posts_url( $fred_id ) . '">fred</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>';
 
 		$this->assertSame(
 			$expected['hide_empty'],
@@ -235,9 +235,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 
 	public function test_wp_list_authors_echo() {
 		$expected['echo'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a></li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>';
 
 		$this->expectOutputString( $expected['echo'] );
 		wp_list_authors( array( 'echo' => true ) );
@@ -249,9 +249,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 		$url2 = get_author_feed_link( self::$user_ids[2] );
 
 		$expected['feed'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a> (<a href="' . $url1 . '">link to feed</a>)</li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a> (<a href="' . $url2 . '">link to feed</a>)</li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a> (<a href="' . $url0 . '">link to feed</a>)</li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a> (<a href="' . $url1 . '">link to feed</a>)</li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a> (<a href="' . $url2 . '">link to feed</a>)</li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a> (<a href="' . $url0 . '">link to feed</a>)</li>';
 
 		$this->assertSame(
 			$expected['feed'],
@@ -270,9 +270,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 		$url2 = get_author_feed_link( self::$user_ids[2] );
 
 		$expected['feed_image'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a> <a href="' . $url1 . '"><img src="http://' . WP_TESTS_DOMAIN . '/path/to/a/graphic.png" style="border: none;" /></a></li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a> <a href="' . $url2 . '"><img src="http://' . WP_TESTS_DOMAIN . '/path/to/a/graphic.png" style="border: none;" /></a></li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a> <a href="' . $url0 . '"><img src="http://' . WP_TESTS_DOMAIN . '/path/to/a/graphic.png" style="border: none;" /></a></li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a> <a href="' . $url1 . '"><img src="http://' . WP_TESTS_DOMAIN . '/path/to/a/graphic.png" style="border: none;" /></a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a> <a href="' . $url2 . '"><img src="http://' . WP_TESTS_DOMAIN . '/path/to/a/graphic.png" style="border: none;" /></a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a> <a href="' . $url0 . '"><img src="http://' . WP_TESTS_DOMAIN . '/path/to/a/graphic.png" style="border: none;" /></a></li>';
 
 		$this->assertSame(
 			$expected['feed_image'],
@@ -294,9 +294,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 		$url2 = get_author_feed_link( self::$user_ids[2], 'atom' );
 
 		$expected['feed_type'] =
-			'<li><a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a> (<a href="' . $url1 . '">link to feed</a>)</li>' .
-			'<li><a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a> (<a href="' . $url2 . '">link to feed</a>)</li>' .
-			'<li><a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a> (<a href="' . $url0 . '">link to feed</a>)</li>';
+			'<li><a href="' . self::$user_urls[1] . '">bob</a> (<a href="' . $url1 . '">link to feed</a>)</li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a> (<a href="' . $url2 . '">link to feed</a>)</li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a> (<a href="' . $url0 . '">link to feed</a>)</li>';
 
 		$this->assertSame(
 			$expected['feed_type'],
@@ -312,9 +312,9 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 
 	public function test_wp_list_authors_style() {
 		$expected['style'] =
-			'<a href="' . self::$user_urls[1] . '" title="Posts by bob">bob</a>, ' .
-			'<a href="' . self::$user_urls[2] . '" title="Posts by paul">paul</a>, ' .
-			'<a href="' . self::$user_urls[0] . '" title="Posts by zack">zack</a>';
+			'<a href="' . self::$user_urls[1] . '">bob</a>, ' .
+			'<a href="' . self::$user_urls[2] . '">paul</a>, ' .
+			'<a href="' . self::$user_urls[0] . '">zack</a>';
 
 		$this->assertSame(
 			$expected['style'],


### PR DESCRIPTION
Removes title attributes from
- `get_the_author_link()`
- `get_the_author_posts_link()`
- `wp_list_authors()`

Props: adnan.limdi

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
