### PR TITLE
Fix unclickable links in Twenty Eleven

### DIFF
--- a/src/wp-content/themes/twentyeleven/rtl.css
+++ b/src/wp-content/themes/twentyeleven/rtl.css
@@ -517,6 +517,9 @@ section.recent-posts .other-recent-posts .comments-link > span {
 		left: auto;
 		right: 0;
 	}
+	.singular #author-info {
+		margin: 2.2em -8.8% 0;
+	}
 	/* Make sure we have room for our comment avatars */
 	.commentlist > li.comment,
 	.commentlist .pingback {

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -2580,7 +2580,7 @@ p.comment-form-comment {
 	/* Make sure the post-post navigation doesn't collide with anything */
 	#nav-single {
 		display: block;
-		position: static;
+		top: 0;
 	}
 	.singular .hentry {
 		padding: 1.625em 0 0;


### PR DESCRIPTION
A simpler patch than https://github.com/WordPress/wordpress-develop/pull/7549, this would fix the unclickable links when the screen is narrower than 650 pixels.

- Maintains the single post navigation's `relative` positioning at the 650px breakpoint, but edits the `top` value to `0`.
- Corrects the RTL margins for post author description at the 800px breakpoint (when the author profile has a biography and the site has multiple authors).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
