### PR TITLE
Block themes: pre element overflow

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/theme.json
+++ b/src/wp-content/themes/twentytwentyfive/theme.json
@@ -682,6 +682,9 @@
 						"textDecoration": "none"
 					}
 				}
+			},
+			"pre": {
+				"css": "&{overflow-x:auto;}"
 			}
 		}
 	},

--- a/src/wp-content/themes/twentytwentyfour/theme.json
+++ b/src/wp-content/themes/twentytwentyfour/theme.json
@@ -891,6 +891,9 @@
 				"color": {
 					"text": "var(--wp--preset--color--contrast)"
 				}
+			},
+			"pre": {
+				"css": "&{overflow-x:auto;}"
 			}
 		},
 		"spacing": {

--- a/src/wp-content/themes/twentytwentythree/theme.json
+++ b/src/wp-content/themes/twentytwentythree/theme.json
@@ -699,6 +699,9 @@
 				"typography": {
 					"textDecoration": "underline"
 				}
+			},
+			"pre": {
+				"css": "&{overflow-x:auto;}"
 			}
 		},
 		"spacing": {

--- a/src/wp-content/themes/twentytwentytwo/theme.json
+++ b/src/wp-content/themes/twentytwentytwo/theme.json
@@ -338,6 +338,9 @@
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
 				}
+			},
+			"pre": {
+				"css": "&{overflow-x:auto;}"
 			}
 		},
 		"spacing": {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -600,7 +600,8 @@ class WP_Theme_JSON {
 	 * The valid elements that can be found under styles.
 	 *
 	 * @since 5.8.0
-	 * @since 6.1.0 Added `heading`, `button`, and `caption` elements.
+	 * @since 6.1.0 Added `heading`, `button`, `caption`, and `cite` elements.
+	 * @since 6.9.0 Added `pre` element.
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
@@ -617,6 +618,7 @@ class WP_Theme_JSON {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'    => 'cite',
+		'pre'     => 'pre',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(


### PR DESCRIPTION
[Core Trac 63875](https://core.trac.wordpress.org/ticket/63875)

Potential method to add CSS for `pre` elements in block themes, especially T23 and T24 because they have no stylesheet. It prints the following rule in global styles, but it avoids changing the user-editable Additional CSS after the themes are publicly available.
```
:root :where(pre) {
  overflow-x: auto;
}
```

Editing the `ELEMENTS` array would require a separate discussion on the Gutenberg repository.

Note: I was warned about incorrect line endings in my changes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
