### PR TITLE
Use `is_string` in `wp_title` to prevent deprecation notice

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1424,8 +1424,12 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 		$title = __( 'Page not found' );
 	}
 
+	if ( ! is_string( $title ) ) {
+		$title = '';
+	}
+
 	$prefix = '';
-	if ( ! empty( $title ) ) {
+	if ( '' !== $title ) {
 		$prefix = " $sep ";
 	}
 
@@ -1436,7 +1440,7 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 	 *
 	 * @param string[] $title_array Array of parts of the page title.
 	 */
-	$title_array = apply_filters( 'wp_title_parts', ! empty( $title ) ? explode( $t_sep, $title ) : array() );
+	$title_array = apply_filters( 'wp_title_parts', explode( $t_sep, $title ) );
 
 	// Determines position of the separator and direction of the breadcrumb.
 	if ( 'right' === $seplocation ) { // Separator on right, so reverse the order.


### PR DESCRIPTION
Checks whether `$title` is a string and then checks whether it equals an empty string for the separator.

[Trac 61352](https://core.trac.wordpress.org/ticket/61352)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
