### PR TITLE
Support directory relative references in `esc_url()`

### DIFF
--- a/tests/phpunit/tests/formatting/escUrl.php
+++ b/tests/phpunit/tests/formatting/escUrl.php
@@ -311,4 +311,13 @@ EOT;
 		$this->assertSame( '//[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( '//[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 		$this->assertSame( 'http://[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( 'http://[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 	}
+
+	/**
+	 * @ticket 46791
+	 */
+	public function test_directory_relative_references() {
+		$this->assertSame( './current-directory', esc_url( './current-directory' ) );
+		$this->assertSame( '../parent-directory', esc_url( '../parent-directory' ) );
+		$this->assertSame( '../../../../up-four-directories', esc_url( '../../../../up-four-directories' ) );
+	}
 }


### PR DESCRIPTION
Does not prepend the fallback protocol when the reference starts with a dot (`./` or `../`).

[Trac 46791](https://core.trac.wordpress.org/ticket/46791)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
