### PR TITLE
Use flex in the admin Toolbar to handle overflow

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -99,9 +99,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 	background: #1d2327;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
-	overflow-x: auto;
-	overflow-y: hidden;
-	scrollbar-width: thin;
 }
 
 #wpadminbar,
@@ -858,6 +855,18 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper a:empty {
 		display: none;
+	}
+
+	/* Scrolls any overflow, but hides all dropdowns even when there is no overflow */
+	#wpadminbar {
+		overflow-x: auto;
+		overflow-y: hidden;
+		scrollbar-width: thin;
+	}
+
+	#wpadminbar .ab-sub-wrapper,
+	#wpadminbar .shortlink-input {
+		display: none !important;
 	}
 
 	/* WP logo */

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -99,6 +99,29 @@ html:lang(he-il) .rtl #wpadminbar * {
 	background: #1d2327;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: thin;
+}
+
+#wpadminbar,
+#wpadminbar #wp-toolbar,
+#wpadminbar #wp-toolbar > ul,
+#wpadminbar .ab-top-menu {
+	display: flex;
+	flex-wrap: nowrap;
+}
+
+#wpadminbar #wp-toolbar {
+	justify-content: space-between;
+	width: 100%;
+}
+
+#wpadminbar #wp-toolbar > ul > li > .ab-item {
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	min-width: 16px;
+	overflow: hidden;
 }
 
 #wpadminbar .ab-sub-wrapper,
@@ -120,10 +143,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar .quicklinks ul {
 	text-align: left;
-}
-
-#wpadminbar li {
-	float: left;
 }
 
 #wpadminbar .ab-empty-item {
@@ -372,10 +391,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .quicklinks a:hover span#ab-updates {
 	background: #fff;
 	color: #000;
-}
-
-#wpadminbar .ab-top-secondary {
-	float: right;
 }
 
 #wpadminbar ul li:last-child,


### PR DESCRIPTION
Removes the floating and uses flex for the entire bar.
- Uses ellipses for text overflow on larger screens, as in https://github.com/WordPress/wordpress-develop/pull/1082
- With `overflow-x: auto` to scroll horizontally (on smaller screens), the vertical overflow is hidden, which will not show the flyout/dropdown menus. That might be an improvement for someone who chooses it, but it is not acceptable for everyone. Even when the menu items have plenty of horizontal space, this cuts off the vertical menus.

[Trac 28983](https://core.trac.wordpress.org/ticket/28983)

Use of AI Tools: None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
